### PR TITLE
fix releases, fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # BitZeny's Bootstrap
 
+[日本語](https://github.com/BitZenyChains/BootStrap/blob/master/README.ja.md)  
+[release](https://github.com/BitZenyChains/BootStrap/blob/master/releases.ja.md)
+
+<!-- 英訳頼む -->

--- a/releases.ja.md
+++ b/releases.ja.md
@@ -1,0 +1,22 @@
+# Bootstrapの生成方法
+
+## linux
+```bash
+cd .bitzeny/blocks
+ls -1 blk[0-9]*.dat | sort | xargs cat > bootstrap.dat
+```
+
+## Windows
+```bash
+cd %appdata%\BitZeny\blocks
+COPY /b blk00001.dat+blk00002.dat+blk00003.dat+blk00004.dat bootstrap.dat
+```
+
+## リリース
+
+1. `bootstrap.dat`を`tar.gz`、`7z`に圧縮
+2. `new release`より作成、作成したbootstrapをアップロード
+3. 説明文に下記添付
+    1. 作成者
+    2. 作成日時
+    3. チェックサム(sha256等)


### PR DESCRIPTION
README.md側に日本語版へのリンク
release説明文すっかり抜けてました